### PR TITLE
Optimize the bot via removed endl

### DIFF
--- a/protocols/irc.cpp
+++ b/protocols/irc.cpp
@@ -203,17 +203,17 @@ IRCChat::GetMessage()
   }
 
 #ifdef LOGGING
-  std::cout << "COMMAND: " + m->command + "\nARGUMENTS" << std::endl;
+  std::cout << "COMMAND: " + m->command + "\nARGUMENTS" << '\n';
   for (auto i = m->argList.begin(); i != m->argList.end(); ++i)
   {
-    std::cout << "\t" + *i << std::endl;
+    std::cout << "\t" + *i << '\n';
   }
-  std::cout << "MESSAGE: " + m->str << std::endl;
-  std::cout << "NICKNAME: " + m->nickname << std::endl;
-  std::cout << "USERNAME: " + m->username << std::endl;
-  std::cout << "HOSTNAME: " + m->hostname << std::endl;
-  std::cout << "SERVERNAME: " + m->servername << std::endl;
-  std::cout << "PREFIX: " + m->prefix << std::endl;
+  std::cout << "MESSAGE: " + m->str << '\n';
+  std::cout << "NICKNAME: " + m->nickname << '\n';
+  std::cout << "USERNAME: " + m->username << '\n';
+  std::cout << "HOSTNAME: " + m->hostname << '\n';
+  std::cout << "SERVERNAME: " + m->servername << '\n';
+  std::cout << "PREFIX: " + m->prefix << '\n';
 #endif
 
   if (m->nickname == "DEFAULT_ADMIN")
@@ -232,7 +232,7 @@ IRCChat::GetMessage()
 IRCChat::SendMessage(Message *m)
 {
 #ifdef LOGGING
-  std::cout << m->GetFormattedString() << std::endl;
+  std::cout << m->GetFormattedString() << '\n';
 #endif
   socket->Send(m->GetFormattedString());
 }

--- a/src/socket_posix.cpp
+++ b/src/socket_posix.cpp
@@ -20,7 +20,7 @@ Socket::Send(std::string message)
   if (send(socketFd, message.c_str(), message.length(), 0) == -1)
   {
     // TODO: Proper exception.
-    std::cout << "Send failed!" << std::endl;
+    std::cout << "Send failed!\n";
     close(socketFd);
     return;
   }
@@ -39,12 +39,12 @@ Socket::Recv()
   }
   else if (resultCode == 0)
   {
-    std::cout << "Connection closed." << std::endl;
+    std::cout << "Connection closed.\n";
     return "";
   }
   else
   {
-    std::cout << "Recv failed." << std::endl;
+    std::cout << "Recv failed.\n";
     return "";
   }
   return out;

--- a/src/socket_windows.cpp
+++ b/src/socket_windows.cpp
@@ -41,11 +41,11 @@ Socket::Recv()
   }
   else if (resultCode == 0)
   {
-    std::cout << "Connection closed" << std::endl;
+    std::cout << "Connection closed\n";
   }
   else
   {
-    std::cout << "Recv failed" << std::endl;
+    std::cout << "Recv failed\n";
   }
   return out;
 }


### PR DESCRIPTION
std::endl is notorious for slowing down stream output due to needing to flush with each output. That isn't really necessary in this use case, so the code would be more consistent (and faster) with newline escape characters instead.

Note: These commits need to be squashed. I'd do it myself, but as of writing this, I have no access to a git-equipped machine.
